### PR TITLE
ランスルーを通して気づいたアイディア

### DIFF
--- a/01_getting_started.md
+++ b/01_getting_started.md
@@ -28,7 +28,7 @@ Node-RED はローコードプログラミングな手軽なアプローチで S
 
 ですので今日は、おおよそ 30 ～ 40 分で 1 つのハンズオンで行い、合計 2 つのハンズオンを行います。途中で 1 つめのハンズオンが終わったら Katacoda をリロードして起動しなおします。
 
-## Katacoda での Node-RED の準備
+## [実践]: Katacoda での Node-RED の準備
 
 教材はこちらです。
 
@@ -117,7 +117,7 @@ https://www.katacoda.com/kazuhitoyokoi/scenarios/node-red
 
 などがあります。
 
-## inject ノードと debug ノードをつなげていく
+## [実践]: inject ノードと debug ノードをつなげていく
 
 ![image](https://i.gyazo.com/69d9424ea7db4779794c1d39e1d0a44f.png)
 
@@ -137,7 +137,7 @@ inject ノードと debug ノードをつなぎます。つなぐものはワイ
 
 ![image](https://i.gyazo.com/6d69e6990487e06533edba753d67904e.png)
 
-## 動かしてみる
+## [実践]: 動かしてみる
 
 ![image](https://i.gyazo.com/486f98add3229d4cc880359bf1b3b643.png)
 
@@ -151,7 +151,7 @@ debugノードのデータはサイドバーのデバッグタブをクリック
 
 injectノードの横のボタンを押すとdebugノードにデータが送られます。今回はinjectノードは日付（タイムスタンプ）を送っています。さきほどのデバッグタブでdebugノードが受け付けたデータを確認できます。
 
-## injectノードで送るデータを変更
+## [実践]: injectノードで送るデータを変更
 
 injectノードをダブルクリックしてデータを変更しましょう。
 

--- a/02_api_request.md
+++ b/02_api_request.md
@@ -51,7 +51,7 @@ API につなげるためには HTTP という通信のルール（プロトコ�
 
 今回は、私が別の機会に書いた [すぐにAPIを体験！public\-apis 100以上のJavaScript axiosサンプル集](https://protoout.studio/posts/public-apis-api-get) を使っていきます。
 
-## Node-RED で http request する仕組みを作ってみる
+## [実践]: Node-RED で http request する仕組みを作ってみる
 
 ![image](https://i.gyazo.com/baedc63f4a27f63eb33277aeb49481eb.png)
 
@@ -92,7 +92,7 @@ HTTP リクエストの仕様として読み解くと以下のようになりま
 
 これのみです。追加で設定すべきパラメータもなく、これは、GET リクエストのためブラウザからアクセスでき、とても扱いやすいAPIです。
 
-## Node-RED の http request ノードに設定してみる
+## [実践]: Node-RED の http request ノードに設定してみる
 
 ![image](https://i.gyazo.com/5eedcc78773990656fca5301fbc7acf4.png)
 
@@ -119,7 +119,7 @@ HTTP リクエストの仕様として読み解くと以下のようになりま
 
 デプロイをクリックして Node-RED に設定を反映させます。
 
-## 動かしてみる
+## [実践]: 動かしてみる
 
 ![image](https://i.gyazo.com/d02727178bb7fb092a36642e2eb0d9ee.png)
 
@@ -129,13 +129,15 @@ HTTP リクエストの仕様として読み解くと以下のようになりま
 
 サイドバーのデバッグタブには、猫画像APIからリクエストが表示されます。
 
-## 返答データを文字列からJSONに変更する
+## [実践]: 返答データを文字列からJSONに変更する
 
 ![image](https://i.gyazo.com/e0354e1cefe80b1ebf9bc905cc081d2c.png)
 
 現状では取得したデータは文字列です。今後扱いやすいようにJSONに変更しましょう。
 
 文字列のままだと頑張って読んで探して取り出す必要がありますが、JSONデータで受け取れると入れ子構造で目的のデータが取り出しやすくなります。
+
+それでは、http request ノードをダブルクリックをしてプロパティ編集画面を表示します。
 
 ![image](https://i.gyazo.com/7ad33f4cec6e1be03622557bd9af245e.png)
 

--- a/03_cat_image_output.md
+++ b/03_cat_image_output.md
@@ -12,7 +12,7 @@
 
 このようにAPIの仕様をつかんで、JSONデータの中身を理解して、必要なデータを取り出せるようになると、さまざまなAPIを自分好みに使えたり、他のAPIとも連携できるようになるのでやってみましょう。
 
-## change ノードをフローに準備する
+## [実践]: change ノードをフローに準備する
 
 ![image](https://i.gyazo.com/82db4f456538ca13751287e836c5858e.png)
 
@@ -34,7 +34,7 @@ change ノードを入れるために http request ノードと debug ノード 
 
 これで change ノードが入りました。
 
-## change ノードでデータを取り出す
+## change ノードでデータを取り出すには？
 
 ![image](https://i.gyazo.com/5d4495a528da6b9f46abeb89bc501975.png)
 
@@ -83,9 +83,18 @@ JSONata はドットを使って JSON データの中身を取り出すことが
 
 payload の中の file という値ということで `payload.file` となります。
 
+## [実践]: change ノードでデータを取り出す
+
+それでは、実際に設定していきましょう。まず、change ノードをダブルクリックしてプロパティの編集画面を開きます。
+
+「ルール」を下記のように変更します。
+
+- 「対象の値」の種類を「JSONate式」（英語では expression）に変更する
+- 「対象の値」の値（入力欄）に `payload.file` を入力する
+
 ![image](https://i.gyazo.com/c90a6a04c6331cf86752db74d30fb177.png)
 
-下部の JSONata の値として猫画像を file を取り出すために `payload.file` と記述しましょう。
+この指定により、`payload.file` に指定されている猫画像を指定することができます。
 
 ![image](https://i.gyazo.com/dcc16d4d8fa6f944b138e2c65b081d64.png)
 
@@ -103,7 +112,7 @@ payload の中の file という値ということで `payload.file` となり�
 
 デバッグタブを見てみると、無事 file の中身が取り出されて猫画像の URL だけが取り出すことができました。
 
-## 画像を表示するノード node-red-contrib-image-output ノードを追加
+## [実践]: 画像を表示するノード node-red-contrib-image-output ノードを追加
 
 さて、画像を表示するノードですが、標準のノード群には存在していません。
 
@@ -156,7 +165,7 @@ node-red-contrib-image-output と入力して検索して、 node-red-contrib-im
 
 しばらく待っているとインストールが完了します。
 
-## node-red-contrib-image-output ノードをフローに加える
+## [実践]: node-red-contrib-image-output ノードをフローに加える
 
 node-red-contrib-image-output ノードを加えて、画像を表示しましょう。
 
@@ -194,7 +203,7 @@ inject ノードをクリックして猫画像が node-red-contrib-image-output 
 
 画像が表示されるはずです！
 
-## 画像を大きくしたいとき
+## [実践]: 画像を大きくしたいとき
 
 ![image](https://i.gyazo.com/018e05bc6e6c32f14a96e32d2405ca8c.png)
 


### PR DESCRIPTION
変更したところは下記です。
- 説明なのか、手順なのかわかりにくかったので、手順の部分に `[実践]:` と追記してみました

修正箇所が多くなるため下記は対応していませんが、ご参考までに 🙏 
- 画像にはクリックする場所や入力する場所を四角で囲うとより分かりやすそうです
- 個人の感覚かもしれませんが、画像→手順ではなくて、手順→画像の順の方がわかりやすい気がしています
- Katacode の Node-RED が英語で表示されるなら、手順も英語の方がよさそう…？